### PR TITLE
Add Molecule Docker driver

### DIFF
--- a/{{cookiecutter.role_slug}}/requirements.in
+++ b/{{cookiecutter.role_slug}}/requirements.in
@@ -3,6 +3,6 @@ ansible
 ansible-lint
 docker
 mkdocs
-molecule
+molecule[docker]
 pip-tools
 yamllint


### PR DESCRIPTION
Molecule no longer includes the Docker driver by default. This ensures that the Docker driver gets installed.